### PR TITLE
Cross Origin Request Headers hinzufügen

### DIFF
--- a/server.py
+++ b/server.py
@@ -207,7 +207,16 @@ def station_departuress(station_id):
     details = get_departures(station_id)
     return json.dumps(details)
 
-
+# Add CORS header to every request
+@app.after_request
+def add_cors(resp):
+    resp.headers['Access-Control-Allow-Origin'] = request.headers.get('Origin','*')
+    resp.headers['Access-Control-Allow-Credentials'] = 'true'
+    resp.headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS, GET'
+    resp.headers['Access-Control-Allow-Headers'] = request.headers.get('Access-Control-Request-Headers', 'Authorization' )
+    if app.debug:
+        resp.headers['Access-Control-Max-Age'] = '1'
+    return resp
 
 if __name__ == "__main__":
     stations = get_stations()


### PR DESCRIPTION
Fügt den Server-Antworten den Access-Control-Allow-Origin Header hinzu,
nach CORS Standards.
Verhindert Fehler bei API-Anfragen per XMLHttpRequest.
